### PR TITLE
Fixed calc_circular_pitch to use unit_factor freeing the Tooth system…

### DIFF
--- a/gears-dev.inx
+++ b/gears-dev.inx
@@ -8,11 +8,17 @@
 	<param name='active-tab' type="notebook">
 		<page name="Gear" _gui-text="Gears">
 			<param name="teeth"     type="int"     min="3"    max="1200"    _gui-text="Number of teeth (3..1200)">24</param>
-			<param name="dimension" type="float"   min="0.1"  max="1000.0"	precision="5"	_gui-text="Tooth size (Module, CP, DP)">1.0</param>
+			<param name="dimension" type="float"   min="0.0001"  max="1000.0"	precision="5"	_gui-text="Tooth size (Module, CP, DP)">1.0</param>
+			<param name="units"     type="optiongroup" appearance="minimal" _gui-text="Units">
+				<option value="mm">mm</option>
+				<option value="cm">cm</option>
+				<option value="in">in</option>
+				<option value="pt">pt</option>
+				<option value="px">px</option></param>
 			<param name="system"    _gui-text="Tooth system" type="optiongroup">
-				<_option value="MM">Module (mm)</_option>
-				<_option value="CP">Circular Pitch (in)</_option>
-				<_option value="DP">Diametral Pitch (in)</_option>
+				<_option value="MM">Module</_option>
+				<_option value="CP">Circular Pitch</_option>
+				<_option value="DP">Diametral Pitch</_option>
 			</param>
 			<_param name="help"     type="description" xml:space="preserve">------------------------------</_param>
 			<param name="angle"     type="float"   min="5.0"  max="45.0"   	precision="1"	_gui-text="Pressure angle (5..45)">20.0</param>
@@ -21,12 +27,6 @@
 			<param name="annotation"  type="boolean" _gui-text="Draw annotation text">false</param>
 		</page>	
 		<page name='advanced' _gui-text='Advanced options'>
-			<param name="units"     type="optiongroup" appearance="minimal" _gui-text="Units">
-				<option value="mm">mm</option>
-				<option value="cm">cm</option>
-				<option value="in">in</option>
-				<option value="pt">pt</option>
-				<option value="px">px</option></param>
 			<param name="clearance" type="float"   min="0"    max="100"     precision="3"	_gui-text="Clearance (bottom)">0</param>
 			<param name="profile-shift" type="float" min="-50" max="50"     precision="1"	_gui-text="Profile shift [% of module]">0</param>
 			<param name="internal-ring"			type="boolean" _gui-text="Ring gear (Internal gear)">false</param>


### PR DESCRIPTION
Changed the calc_circular_pitch function to use the declared measurements units parameter instead of static units of mm for module and inch for the others.  This keeps the units of measurement used throughout the extension uniform, instead the dimension units being fixed based on the tooth system and the rest being declarative based on the units parameter.  Also moved the Units parameter to the first page of the extension dialog and removed the unit designations from the tooth system option labels.

Also added the root_diameter to the annotation text so I could see the effect of the clearance parameter.